### PR TITLE
Build salon CRM marketing demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Salon CRM Demo — GitHub Pages Ready
+
+This repository contains a front-end only marketing + CRM demonstration site for a multi-location salon franchise. It is optimized for GitHub Pages hosting and illustrates the flow from lead capture through segmentation and campaign previews.
+
+## Local development
+
+Serve the files with any static web server or simply open `index.html` in your browser. Because all functionality is client-side, no build step is required.
+
+```bash
+python -m http.server 3000
+```
+
+Navigate to `http://localhost:3000/` to explore the marketing site. Visit `/demo.html` for the internal dashboard walkthrough.
+
+## Resetting demo data
+
+The lead form stores submissions in `localStorage` under the key `demo_leads`. To clear the demo data, run the following in the browser console:
+
+```js
+localStorage.removeItem('demo_leads');
+```
+
+Refresh `/demo.html` and click **Refresh leads** to reload seeded data only.
+
+## Google Analytics 4 (Optional)
+
+Analytics is controlled via `data/config.json`:
+
+- `ga4MeasurementId`: supply your GA4 property ID (e.g., `G-XXXXXXX`).
+- `features.enableAnalytics`: set to `false` to disable GA script injection.
+
+The following custom events are fired when analytics is enabled:
+
+- `lead_submit` — after the form is successfully validated and stored.
+- `segment_apply` — when filters change in the demo dashboard.
+- `campaign_preview` — when the preview button is clicked in the campaign studio.
+
+## Data seeds
+
+Sample data lives in `/data/*.json` and is fetched on the client. Feel free to extend the seed files with additional leads, services, or locations to tailor demos.
+
+## Keyboard shortcuts
+
+Press the `D` key on any page to jump directly to the demo dashboard (`/demo.html`).
+
+## Lighthouse & performance
+
+The site uses Tailwind via CDN and no heavy frameworks to stay within the 150 KB JS budget. Images are lazy-loaded via the `loading="lazy"` attribute.
+
+## Deployment checklist
+
+1. Enable GitHub Pages for the repository root (or `/docs` if you relocate files).
+2. Ensure `.nojekyll` remains present so data files load.
+3. Update `data/config.json` with your GA measurement ID if tracking is desired.
+4. Optionally add a Lighthouse report under `/reports` before sharing the public URL.

--- a/data/campaigns.json
+++ b/data/campaigns.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "ct_new_color",
+    "name": "New Color Guests",
+    "email": {
+      "subject": "First color, first wow",
+      "headline": "Color Confidence Starts Here",
+      "body": "See why 12k guests trust our color pros. Enjoy a gloss upgrade when you book by Friday.",
+      "cta": "Schedule my consult"
+    },
+    "sms": {
+      "text": "Ready to go bold? Book color by Friday and your gloss upgrade is on us. Reply STOP to opt out."
+    },
+    "defaultFilters": {"interest": "Color", "lastVisitDaysGt": 30}
+  },
+  {
+    "id": "ct_vip_reactivation",
+    "name": "VIP Reactivation",
+    "email": {
+      "subject": "We miss you, VIP",
+      "headline": "VIP Offer: 20% Off Color",
+      "body": "Reserve with your favorite artist and receive a luxe treatment on us.",
+      "cta": "Book VIP refresh"
+    },
+    "sms": {
+      "text": "VIP perk unlocked: 20% off color this week. Tap to reserve—reply STOP to opt out."
+    },
+    "defaultFilters": {"membership": "VIP", "lastVisitDaysGt": 60}
+  },
+  {
+    "id": "ct_membership",
+    "name": "Membership Upgrade",
+    "email": {
+      "subject": "Unlock unlimited styling",
+      "headline": "Blowout Society Awaits",
+      "body": "Members save 25% on retail and get surprise upgrades every month.",
+      "cta": "Upgrade my membership"
+    },
+    "sms": {
+      "text": "Fresh styles on repeat—membership includes 2 blowouts monthly. Join now! Reply STOP to opt out."
+    },
+    "defaultFilters": {"membership": "Signature"}
+  }
+]

--- a/data/config.json
+++ b/data/config.json
@@ -1,0 +1,7 @@
+{
+  "ga4MeasurementId": "G-XXXXXXXXXX",
+  "features": {
+    "enableSmsPreview": true,
+    "enableAnalytics": true
+  }
+}

--- a/data/leads.json
+++ b/data/leads.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ld_001",
+    "firstName": "Jordan",
+    "lastName": "Lee",
+    "email": "jordan.lee@example.com",
+    "phone": "",
+    "preferredLocation": "Austin - Downtown",
+    "interestedServices": ["Color", "Cut"],
+    "membership": "VIP",
+    "lastVisit": "2025-03-15",
+    "createdAt": "2025-04-01T13:45:00Z"
+  },
+  {
+    "id": "ld_002",
+    "firstName": "Alex",
+    "lastName": "Nguyen",
+    "email": "alex.nguyen@example.com",
+    "phone": "5125550199",
+    "preferredLocation": "Austin - North",
+    "interestedServices": ["Styling", "Extensions"],
+    "membership": "Signature",
+    "lastVisit": "2025-04-05",
+    "createdAt": "2025-04-08T09:20:00Z"
+  },
+  {
+    "id": "ld_003",
+    "firstName": "Morgan",
+    "lastName": "Patel",
+    "email": "morgan.patel@example.com",
+    "phone": "",
+    "preferredLocation": "Dallas - Uptown",
+    "interestedServices": ["Color"],
+    "membership": "New",
+    "lastVisit": "2025-02-22",
+    "createdAt": "2025-03-30T21:05:00Z"
+  },
+  {
+    "id": "ld_004",
+    "firstName": "Jamie",
+    "lastName": "Rivera",
+    "email": "jamie.rivera@example.com",
+    "phone": "2145550188",
+    "preferredLocation": "Houston - Heights",
+    "interestedServices": ["Cut", "Treatments"],
+    "membership": "VIP",
+    "lastVisit": "2025-01-12",
+    "createdAt": "2025-03-11T16:30:00Z"
+  }
+]

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "loc_austin_downtown",
+    "name": "Austin - Downtown",
+    "address": "501 Congress Ave, Austin, TX",
+    "phone": "512-555-0145",
+    "hours": "Mon-Sat 8a-8p",
+    "services": ["Color Studio", "Luxury Blowouts", "Membership Lounge"],
+    "city": "Austin",
+    "state": "TX",
+    "zip": "78701"
+  },
+  {
+    "id": "loc_austin_north",
+    "name": "Austin - North",
+    "address": "11800 Research Blvd, Austin, TX",
+    "phone": "512-555-0182",
+    "hours": "Mon-Fri 9a-7p, Sat 9a-5p",
+    "services": ["Family Cuts", "Texture Lab", "Express Styling"],
+    "city": "Austin",
+    "state": "TX",
+    "zip": "78759"
+  },
+  {
+    "id": "loc_dallas_uptown",
+    "name": "Dallas - Uptown",
+    "address": "2700 McKinney Ave, Dallas, TX",
+    "phone": "214-555-0122",
+    "hours": "Daily 9a-8p",
+    "services": ["Extension Bar", "Color Correction", "VIP Suite"],
+    "city": "Dallas",
+    "state": "TX",
+    "zip": "75204"
+  },
+  {
+    "id": "loc_houston_heights",
+    "name": "Houston - Heights",
+    "address": "1502 Yale St, Houston, TX",
+    "phone": "713-555-0107",
+    "hours": "Mon-Sat 8a-8p",
+    "services": ["Curl Collective", "Men's Grooming", "Scalp Spa"],
+    "city": "Houston",
+    "state": "TX",
+    "zip": "77008"
+  }
+]

--- a/data/services.json
+++ b/data/services.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "svc_color_refresh",
+    "name": "Color Refresh & Gloss",
+    "description": "Revive tone and shine with a stylist-customized gloss and hydration boost.",
+    "priceRange": "$120 - $180",
+    "tags": ["Color", "Membership Eligible"]
+  },
+  {
+    "id": "svc_signature_cut",
+    "name": "Signature Cut & Finish",
+    "description": "Precision cut with blowout styling and personalized home care plan.",
+    "priceRange": "$85 - $135",
+    "tags": ["Cut", "Styling"]
+  },
+  {
+    "id": "svc_extension_volume",
+    "name": "Volume Extension Package",
+    "description": "Seamless extensions with maintenance program and VIP lounge access.",
+    "priceRange": "$450 - $900",
+    "tags": ["Extensions", "VIP"]
+  },
+  {
+    "id": "svc_men_groom",
+    "name": "Modern Men's Grooming",
+    "description": "Clipper + scissor blend, hot towel finish, and scalp therapy add-on.",
+    "priceRange": "$65 - $95",
+    "tags": ["Cut", "Treatments"]
+  },
+  {
+    "id": "svc_membership",
+    "name": "Blowout Society Membership",
+    "description": "2 monthly blowouts, product savings, and surprise upgrades for loyal guests.",
+    "priceRange": "$89 / month",
+    "tags": ["Membership", "Styling"]
+  }
+]

--- a/data/stylists.json
+++ b/data/stylists.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "st_riley",
+    "name": "Riley Thompson",
+    "photo": "https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=600&q=80",
+    "locations": ["Austin - Downtown", "Austin - North"],
+    "specialties": ["Balayage", "Short Cuts"],
+    "yearsExperience": 7,
+    "badges": ["Color Pro", "Educator"],
+    "bio": "Educator and award-winning colorist known for effortless lived-in looks."
+  },
+  {
+    "id": "st_charlie",
+    "name": "Charlie Rivera",
+    "photo": "https://images.unsplash.com/photo-1487412947147-5cebf100ffc2?auto=format&fit=crop&w=600&q=80",
+    "locations": ["Houston - Heights"],
+    "specialties": ["Curl Specialist", "Treatments"],
+    "yearsExperience": 9,
+    "badges": ["Texture Expert"],
+    "bio": "Curl whisperer with a focus on healthy hair rituals and scalp wellness."
+  },
+  {
+    "id": "st_avery",
+    "name": "Avery Kim",
+    "photo": "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=600&q=80",
+    "locations": ["Dallas - Uptown"],
+    "specialties": ["Extensions", "Color Correction"],
+    "yearsExperience": 11,
+    "badges": ["Extension Artist", "VIP Concierge"],
+    "bio": "Transforms looks with premium extensions and personalized color journeys."
+  },
+  {
+    "id": "st_maya",
+    "name": "Maya Patel",
+    "photo": "https://images.unsplash.com/photo-1519741497674-611481863552?auto=format&fit=crop&w=600&q=80",
+    "locations": ["Austin - Downtown"],
+    "specialties": ["Bridal Styling", "Blowouts"],
+    "yearsExperience": 6,
+    "badges": ["Bridal Lead"],
+    "bio": "Bridal styling lead crafting statement looks for on-camera confidence."
+  }
+]

--- a/data/testimonials.json
+++ b/data/testimonials.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "testi_001",
+    "quote": "Our franchise retention jumped 18% after rolling out targeted color campaigns from this CRM.",
+    "name": "Taylor Morgan",
+    "title": "VP Marketing, Prism Salon Collective"
+  },
+  {
+    "id": "testi_002",
+    "quote": "The demo dashboard sold our owners. Every stylist sees their VIP guests in seconds.",
+    "name": "Priya Desai",
+    "title": "Franchise Owner, LuxeLocks"
+  },
+  {
+    "id": "testi_003",
+    "quote": "We activated 1,200 lapsed memberships in a quarter. The automations feel bespoke.",
+    "name": "Marcus Chen",
+    "title": "COO, Shear Radiance Studios"
+  }
+]

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Demo Dashboard | Elevate Salon CRM</title>
+    <meta
+      name="description"
+      content="Interactive front-end demo of the Elevate Salon CRM dashboard featuring leads, segments, and campaign previews."
+    />
+    <meta name="robots" content="noindex" />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen bg-sand-50">
+    <header class="sticky top-0 z-40 bg-white/90 backdrop-blur border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="index.html" class="inline-flex items-center gap-2 text-sm text-charcoal-500 hover:text-rose-600">
+            <span class="material-symbols-rounded" aria-hidden="true">arrow_back</span>
+            Back to marketing site
+          </a>
+          <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500 text-white">
+            <span class="material-symbols-rounded" aria-hidden="true">dashboard</span>
+          </span>
+          <div>
+            <p class="text-sm uppercase tracking-wider text-charcoal-500">Elevate CRM Demo</p>
+            <h1 class="text-xl font-semibold text-charcoal-900">Salon Franchise Command Center</h1>
+          </div>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="inline-flex items-center gap-2 text-sm text-charcoal-500"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">bolt</span>Front-end only</span>
+          <a href="index.html#lead" class="primary-btn text-sm">Capture a lead</a>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-4 py-10 space-y-8">
+      <p class="text-charcoal-600 text-sm">
+        Pro tip: Submit the marketing form first, then refresh this page or press “Refresh leads” to see the new record. Use the tabs to walk through the narrative: capture → segment → preview campaign.
+      </p>
+
+      <div class="bg-white border border-sand-200 rounded-3xl shadow-sm overflow-hidden">
+        <div class="border-b border-sand-100 bg-sand-50">
+          <nav class="flex flex-wrap" role="tablist" aria-label="Demo dashboard views">
+            <button class="tab-btn" data-tab="leads" role="tab" aria-selected="true">Leads</button>
+            <button class="tab-btn" data-tab="segments" role="tab" aria-selected="false">Segments</button>
+            <button class="tab-btn" data-tab="campaigns" role="tab" aria-selected="false">Campaigns</button>
+          </nav>
+        </div>
+        <section id="tab-leads" class="tab-panel p-6 md:p-8 space-y-6" role="tabpanel">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 class="text-2xl font-semibold text-charcoal-900">Recent leads</h2>
+              <p class="text-sm text-charcoal-500">Leads combine seeded demo records with anything captured locally.</p>
+            </div>
+            <button id="refresh-leads" class="inline-flex items-center gap-2 rounded-full border border-sand-200 px-4 py-2 text-sm font-medium text-charcoal-700 hover:text-rose-600">
+              <span class="material-symbols-rounded text-rose-500" aria-hidden="true">refresh</span>
+              Refresh leads
+            </button>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-sand-100 text-sm">
+              <thead class="bg-sand-50 text-charcoal-500 uppercase tracking-wide text-xs">
+                <tr>
+                  <th scope="col" class="px-4 py-3 text-left">Lead</th>
+                  <th scope="col" class="px-4 py-3 text-left">Email</th>
+                  <th scope="col" class="px-4 py-3 text-left">Location</th>
+                  <th scope="col" class="px-4 py-3 text-left">Interests</th>
+                  <th scope="col" class="px-4 py-3 text-left">Membership</th>
+                  <th scope="col" class="px-4 py-3 text-left">Captured</th>
+                </tr>
+              </thead>
+              <tbody id="leads-table-body" class="divide-y divide-sand-100 text-charcoal-700"></tbody>
+            </table>
+            <div id="leads-empty" class="hidden text-center py-10 text-charcoal-500">No leads yet. Capture a lead on the marketing site to see it here.</div>
+          </div>
+        </section>
+
+        <section id="tab-segments" class="tab-panel hidden p-6 md:p-8 space-y-6" role="tabpanel">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 class="text-2xl font-semibold text-charcoal-900">Segment builder</h2>
+              <p class="text-sm text-charcoal-500">Mix and match filters to show franchise-ready targeting. Segment size updates instantly.</p>
+            </div>
+            <div class="text-sm text-charcoal-500">Segment size: <span id="segment-size" data-segment-size class="font-semibold text-charcoal-900">0 leads</span></div>
+          </div>
+          <div class="grid lg:grid-cols-[320px_1fr] gap-8">
+            <aside class="space-y-6">
+              <div>
+                <h3 class="text-sm font-semibold text-charcoal-900 uppercase tracking-wide">Location</h3>
+                <div id="filter-location" class="mt-3 space-y-2 text-sm text-charcoal-600"></div>
+              </div>
+              <div>
+                <h3 class="text-sm font-semibold text-charcoal-900 uppercase tracking-wide">Interests</h3>
+                <div id="filter-interest" class="mt-3 space-y-2 text-sm text-charcoal-600"></div>
+              </div>
+              <div>
+                <h3 class="text-sm font-semibold text-charcoal-900 uppercase tracking-wide">Membership</h3>
+                <div id="filter-membership" class="mt-3 space-y-2 text-sm text-charcoal-600"></div>
+              </div>
+              <div>
+                <h3 class="text-sm font-semibold text-charcoal-900 uppercase tracking-wide">Last visit</h3>
+                <select id="filter-last-visit" class="mt-3 w-full rounded-2xl border border-sand-200 px-4 py-2 text-sm text-charcoal-700">
+                  <option value="any">Any time</option>
+                  <option value="30+">30+ days</option>
+                  <option value="60+">60+ days</option>
+                  <option value="90+">90+ days</option>
+                  <option value="never">Never visited</option>
+                </select>
+              </div>
+            </aside>
+            <div class="bg-sand-50 border border-sand-100 rounded-3xl p-6">
+              <h3 class="text-lg font-semibold text-charcoal-900">Preview results</h3>
+              <div id="segment-results" class="mt-4 space-y-3 text-charcoal-600">Apply filters to preview leads.</div>
+            </div>
+          </div>
+        </section>
+
+        <section id="tab-campaigns" class="tab-panel hidden p-6 md:p-8 space-y-6" role="tabpanel">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 class="text-2xl font-semibold text-charcoal-900">Campaign studio</h2>
+              <p class="text-sm text-charcoal-500">Pick a template, personalize the copy, and preview email + SMS instantly.</p>
+            </div>
+            <div class="text-sm text-charcoal-500">Estimated reach: <span id="segment-size-campaign" data-segment-size class="font-semibold text-charcoal-900">0 leads</span></div>
+          </div>
+          <div class="grid lg:grid-cols-[320px_1fr] gap-8">
+            <aside class="space-y-6">
+              <div>
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >Campaign template
+                  <select id="campaign-template" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3 text-sm"></select>
+                </label>
+              </div>
+              <div class="space-y-4">
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >Email subject
+                  <input type="text" id="campaign-subject" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3 text-sm" />
+                </label>
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >Headline
+                  <input type="text" id="campaign-headline" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3 text-sm" />
+                </label>
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >Body
+                  <textarea id="campaign-body" rows="4" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3 text-sm"></textarea>
+                </label>
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >CTA / Offer
+                  <input type="text" id="campaign-offer" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3 text-sm" />
+                </label>
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >SMS copy
+                  <textarea id="campaign-sms" rows="3" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3 text-sm"></textarea>
+                </label>
+              </div>
+              <button id="preview-campaign" class="primary-btn w-full justify-center">Preview campaign</button>
+            </aside>
+            <div class="space-y-6">
+              <div>
+                <h3 class="text-lg font-semibold text-charcoal-900">Email preview</h3>
+                <div id="email-preview" class="mt-3"></div>
+              </div>
+              <div>
+                <h3 class="text-lg font-semibold text-charcoal-900">SMS preview</h3>
+                <div id="sms-preview" class="mt-3"></div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="py-6 text-center text-xs text-charcoal-500">
+      Demo only — refresh to reset state. Clear leads via <code>localStorage.removeItem('demo_leads')</code>.
+    </footer>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const buttons = document.querySelectorAll('.tab-btn');
+        const panels = document.querySelectorAll('.tab-panel');
+        function activateTab(tabName) {
+          buttons.forEach((btn) => {
+            const active = btn.dataset.tab === tabName;
+            btn.className = `tab-btn ${active ? 'bg-white text-rose-600 border-b-2 border-rose-500' : ''}`.trim();
+            btn.setAttribute('aria-selected', active.toString());
+          });
+          panels.forEach((panel) => {
+            panel.classList.toggle('hidden', panel.id !== `tab-${tabName}`);
+          });
+        }
+        buttons.forEach((btn) =>
+          btn.addEventListener('click', () => {
+            activateTab(btn.dataset.tab);
+          })
+        );
+        activateTab('leads');
+      });
+    </script>
+    <script src="scripts/navigation.js" type="module"></script>
+    <script src="scripts/demo-dashboard.js" type="module"></script>
+  </body>
+</html>

--- a/demo.html
+++ b/demo.html
@@ -14,7 +14,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Salon CRM Demo | Franchise Marketing Reinvented</title>
+    <meta
+      name="description"
+      content="See how our salon CRM powers multi-location growth: capture leads, segment guests, and launch campaigns in minutes."
+    />
+    <meta property="og:title" content="Salon CRM Demo — Franchise Marketing Reinvented" />
+    <meta
+      property="og:description"
+      content="Walk through the lead-to-loyalty journey for a salon franchise. Capture leads, segment by interest, and preview VIP campaigns."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://org.github.io/salon-crm-demo/" />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1519415943484-9fa1873496ac?auto=format&fit=crop&w=1200&q=80" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Salon CRM Demo — Franchise Marketing Reinvented" />
+    <meta
+      name="twitter:description"
+      content="Unlock high-performing campaigns for every salon location with our CRM demo."
+    />
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1519415943484-9fa1873496ac?auto=format&fit=crop&w=1200&q=80" />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+            <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+              <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+            </span>
+            Elevate CRM
+          </a>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+            <a href="index.html" class="hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Home</a>
+            <a href="services.html" class="hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Services</a>
+            <a href="stylists.html" class="hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Stylists</a>
+            <a href="locations.html" class="hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Locations</a>
+            <a href="testimonials.html" class="hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Testimonials</a>
+            <a href="#lead" class="hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Contact</a>
+          </nav>
+          <div class="flex items-center gap-4">
+            <a href="#lead" class="hidden md:inline-flex primary-btn text-sm">Get a free consultation</a>
+            <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+              <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="services.html" class="hover:text-rose-600">Services</a>
+          <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+          <a href="locations.html" class="hover:text-rose-600">Locations</a>
+          <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+          <a href="#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="bg-hero">
+        <div class="max-w-6xl mx-auto px-4 py-20 grid md:grid-cols-2 gap-12 items-center">
+          <div class="space-y-6">
+            <span class="inline-flex items-center gap-2 rounded-full bg-rose-100 text-rose-600 px-4 py-1 text-sm font-medium">
+              <span class="material-symbols-rounded text-rose-500" aria-hidden="true">stars</span>
+              Built for multi-location salon leaders
+            </span>
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight text-charcoal-900">
+              Own every guest journey—from first visit to lifelong member.
+            </h1>
+            <p class="text-lg text-charcoal-600 max-w-xl">
+              Elevate CRM gives your franchise team a single playbook: capture leads, segment intelligently, and activate color,
+              cut, and membership campaigns in minutes—no IT lift required.
+            </p>
+            <div class="flex flex-wrap gap-4">
+              <a href="#lead" class="primary-btn">Get a free consultation</a>
+              <a href="services.html" class="inline-flex items-center gap-2 font-semibold text-rose-600 hover:text-rose-700">
+                View services
+                <span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span>
+              </a>
+            </div>
+            <div class="flex flex-wrap gap-6 pt-6 text-sm text-charcoal-600">
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">group</span>4.7M guest profiles unified</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">schedule</span>15% faster rebooking</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">paid</span>22% lift in VIP revenue</span>
+            </div>
+          </div>
+          <div class="gradient-border">
+            <div class="inner p-1">
+              <div class="bg-white rounded-[1.9rem] overflow-hidden shadow-xl">
+                <img
+                  src="https://images.unsplash.com/photo-1522336572468-97b06e8ef143?auto=format&fit=crop&w=1200&q=80"
+                  alt="Salon team collaborating"
+                  class="w-full h-72 object-cover"
+                  loading="lazy"
+                  width="600"
+                  height="400"
+                />
+                <div class="p-6 space-y-4">
+                  <h2 class="text-2xl font-semibold text-charcoal-900">Demo the franchise growth playbook</h2>
+                  <ul class="space-y-3 text-charcoal-600">
+                    <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">check</span>Lead routing by location & expertise</li>
+                    <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">check</span>VIP segmentation + win-back scoring</li>
+                    <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">check</span>Email & SMS previews ready for showtime</li>
+                  </ul>
+                  <a href="demo.html" class="inline-flex items-center gap-2 font-semibold text-rose-600 hover:text-rose-700">Preview the dashboard<span class="material-symbols-rounded" aria-hidden="true">arrow_outward</span></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-16 bg-sand-50 border-y border-sand-100">
+        <div class="max-w-6xl mx-auto px-4">
+          <div class="grid md:grid-cols-3 gap-10">
+            <div>
+              <p class="text-sm uppercase tracking-wider text-charcoal-500">Trusted by franchise innovators</p>
+              <h2 class="section-heading mt-3">Designed for scale across 120+ salons</h2>
+            </div>
+            <div class="md:col-span-2 grid sm:grid-cols-2 gap-6">
+              <article class="bg-white rounded-3xl border border-sand-200 p-6 shadow-sm">
+                <h3 class="text-lg font-semibold text-charcoal-900">Location intelligence</h3>
+                <p class="mt-2 text-charcoal-600">Stack rank salons by member growth, stylist capacity, and campaign health to drive weekly standups.</p>
+              </article>
+              <article class="bg-white rounded-3xl border border-sand-200 p-6 shadow-sm">
+                <h3 class="text-lg font-semibold text-charcoal-900">Guest segmentation</h3>
+                <p class="mt-2 text-charcoal-600">Drag-and-drop filters for interest, visit cadence, and memberships—instant reach totals for your pitch.</p>
+              </article>
+              <article class="bg-white rounded-3xl border border-sand-200 p-6 shadow-sm">
+                <h3 class="text-lg font-semibold text-charcoal-900">Campaign previews</h3>
+                <p class="mt-2 text-charcoal-600">Showcase polished email and SMS mockups with merge tags ready for AE storytelling.</p>
+              </article>
+              <article class="bg-white rounded-3xl border border-sand-200 p-6 shadow-sm">
+                <h3 class="text-lg font-semibold text-charcoal-900">Actionable analytics</h3>
+                <p class="mt-2 text-charcoal-600">GA4 events track demo engagement so marketing can optimize the narrative.</p>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-20" aria-labelledby="testimonials-heading">
+        <div class="max-w-6xl mx-auto px-4">
+          <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-10">
+            <div>
+              <h2 id="testimonials-heading" class="section-heading">Franchise leaders love the momentum</h2>
+              <p class="text-charcoal-600 mt-3 max-w-xl">Real-world operators use our CRM demo to align owners, stylists, and marketing around a single guest playbook.</p>
+            </div>
+            <div class="text-sm text-charcoal-500">Carousel auto-rotates every 6 seconds. Pause by hovering or focus.</div>
+          </div>
+          <div id="testimonial-wrapper" class="relative overflow-hidden rounded-3xl border border-sand-200 bg-white/50" tabindex="0">
+            <div id="testimonial-track" class="flex transition-transform duration-500" data-active-index="0"></div>
+            <div class="flex justify-center gap-3 py-6" id="testimonial-indicators" role="tablist" aria-label="Testimonials"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-20 bg-sand-50 border-y border-sand-100" id="lead">
+        <div class="max-w-6xl mx-auto px-4 grid lg:grid-cols-2 gap-12 items-start">
+          <div class="space-y-6">
+            <h2 class="section-heading">Let’s map your franchise growth in 30 minutes</h2>
+            <p class="text-charcoal-600">Share a few details and an Elevate growth specialist will personalize the dashboard tour for your brand.</p>
+            <div class="bg-white rounded-3xl border border-sand-200 p-6 space-y-4">
+              <h3 class="text-lg font-semibold text-charcoal-900">What you’ll get</h3>
+              <ul class="space-y-3 text-charcoal-600">
+                <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">check_circle</span>Lead capture to campaign walkthrough</li>
+                <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">check_circle</span>Location & stylist playbook templates</li>
+                <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">check_circle</span>Success metrics you can copy into board decks</li>
+              </ul>
+            </div>
+          </div>
+          <div>
+            <div id="lead-errors" class="hidden mb-4 rounded-2xl border border-red-200 bg-red-50 text-red-700 px-4 py-3" role="alert" aria-live="assertive"></div>
+            <form id="lead-form" class="bg-white rounded-3xl border border-sand-200 shadow-lg p-8 space-y-6" aria-describedby="lead-summary">
+              <div class="grid md:grid-cols-2 gap-4">
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >First name
+                  <input type="text" name="firstName" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" autocomplete="given-name" required />
+                </label>
+                <label class="block text-sm font-medium text-charcoal-700"
+                  >Last name
+                  <input type="text" name="lastName" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" autocomplete="family-name" required />
+                </label>
+              </div>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Work email
+                <input type="email" name="email" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" autocomplete="email" required />
+              </label>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Phone (optional)
+                <input type="tel" name="phone" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" autocomplete="tel" />
+              </label>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Preferred location
+                <select name="preferredLocation" id="preferredLocation" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" required>
+                  <option value="">Select a location</option>
+                </select>
+              </label>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Interested services
+                <select name="interestedServices" id="interestedServices" class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" multiple size="4" aria-describedby="services-help">
+                </select>
+                <p id="services-help" class="mt-1 text-xs text-charcoal-500">Hold Cmd/Ctrl to select multiple services.</p>
+              </label>
+              <label class="flex items-start gap-3 text-sm text-charcoal-600">
+                <input type="checkbox" name="marketingConsent" class="mt-1" />
+                <span>I’m okay receiving demo emails and SMS about Elevate CRM (you can opt out anytime).</span>
+              </label>
+              <button type="submit" class="primary-btn w-full justify-center">Submit lead</button>
+            </form>
+            <div id="lead-success" class="hidden bg-white rounded-3xl border border-sand-200 shadow-lg p-8 space-y-4" role="status" aria-live="polite">
+              <div class="flex items-center gap-3 text-rose-600 font-semibold">
+                <span class="material-symbols-rounded" aria-hidden="true">celebration</span>
+                Lead captured
+              </div>
+              <p id="lead-summary" class="text-charcoal-700"></p>
+              <div id="lead-next-steps" class="hidden space-y-3 text-charcoal-600">
+                <p class="font-semibold text-charcoal-900">Next steps</p>
+                <ol class="list-decimal pl-5 space-y-2">
+                  <li>Your lead appears instantly in the demo dashboard (<a href="demo.html" class="text-rose-600">open demo</a>).</li>
+                  <li>Apply a segment like “Color + Downtown” to show reach.</li>
+                  <li>Preview a VIP email and SMS with your custom offer.</li>
+                </ol>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-16">
+        <div class="max-w-6xl mx-auto px-4 grid md:grid-cols-3 gap-8 items-center">
+          <div class="md:col-span-2">
+            <h2 class="section-heading">Scale consistency without sacrificing personal touch</h2>
+            <p class="mt-4 text-charcoal-600">Elevate CRM wraps your marketing ops, stylists, and owners around a single data layer. Build trust with consistent journeys from lead to loyalist.</p>
+          </div>
+          <a href="demo.html" class="primary-btn justify-center">Tour the demo dashboard</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+    <script src="scripts/testimonials.js" type="module"></script>
+    <script src="scripts/lead-form.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/locations.html
+++ b/locations.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Locations | Elevate Salon CRM Demo</title>
+    <meta
+      name="description"
+      content="Browse multi-city salon locations, filter by city or zip, and show how Elevate CRM localizes campaigns."
+    />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+            <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+              <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+            </span>
+            Elevate CRM
+          </a>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+            <a href="index.html" class="hover:text-rose-600">Home</a>
+            <a href="services.html" class="hover:text-rose-600">Services</a>
+            <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+            <a href="locations.html" class="text-rose-600">Locations</a>
+            <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+            <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+          </nav>
+          <div class="flex items-center gap-4">
+            <a href="index.html#lead" class="hidden md:inline-flex primary-btn text-sm">Get a free consultation</a>
+            <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+              <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="services.html" class="hover:text-rose-600">Services</a>
+          <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+          <a href="locations.html" class="text-rose-600">Locations</a>
+          <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="bg-hero border-b border-sand-100">
+        <div class="max-w-6xl mx-auto px-4 py-16 grid lg:grid-cols-[1fr_1.2fr] gap-10 items-center">
+          <div class="space-y-6">
+            <h1 class="text-4xl font-bold text-charcoal-900">Every salon on one map. Every guest on the right journey.</h1>
+            <p class="text-lg text-charcoal-600">Search by region to show how Elevate CRM handles localized campaigns, staff utilization, and membership mix for multi-location operators.</p>
+            <div class="flex flex-wrap gap-4 text-sm text-charcoal-600">
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">location_on</span>Regional heatmaps</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">insights</span>Performance snapshots</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">campaign</span>Localized offers</span>
+            </div>
+          </div>
+          <div class="bg-white rounded-3xl border border-sand-200 shadow-lg p-6 space-y-4">
+            <h2 class="text-xl font-semibold text-charcoal-900">Filter locations</h2>
+            <div class="grid sm:grid-cols-3 gap-4">
+              <label class="block text-sm font-medium text-charcoal-700"
+                >City
+                <input type="text" id="filter-city" data-location-filter class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" placeholder="e.g., Austin" />
+              </label>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >State
+                <input type="text" id="filter-state" data-location-filter class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" placeholder="e.g., TX" />
+              </label>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Zip
+                <input type="text" id="filter-zip" data-location-filter class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3" placeholder="e.g., 787" />
+              </label>
+            </div>
+            <p class="text-sm text-charcoal-500">Filters update instantly. Showcase how marketing can localize a membership push in seconds.</p>
+            <img
+              src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80"
+              alt="Stylists collaborating in a modern salon"
+              class="w-full h-48 object-cover rounded-2xl border border-sand-200"
+              loading="lazy"
+              width="600"
+              height="320"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section class="py-20">
+        <div class="max-w-6xl mx-auto px-4">
+          <h2 class="section-heading mb-8">Salon footprint</h2>
+          <div id="locations-list" class="grid md:grid-cols-2 gap-8"></div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+    <script src="scripts/locations.js" type="module"></script>
+  </body>
+</html>

--- a/locations.html
+++ b/locations.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Salon CRM Demo",
+  "short_name": "SalonCRM",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#fdf9f4",
+  "theme_color": "#d6456e",
+  "icons": [
+    {
+      "src": "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy Notice | Elevate Salon CRM Demo</title>
+    <meta
+      name="description"
+      content="Privacy statement for the Elevate Salon CRM demo experience. Learn how demo data is handled."
+    />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col bg-sand-50">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/90 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+            <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+          </span>
+          Elevate CRM
+        </a>
+        <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="privacy.html" class="text-rose-600">Privacy</a>
+          <a href="terms.html" class="hover:text-rose-600">Terms</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+        <div class="flex items-center gap-4">
+          <a href="index.html#lead" class="hidden md:inline-flex primary-btn text-sm">Book a walkthrough</a>
+          <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+            <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+          </button>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="privacy.html" class="text-rose-600">Privacy</a>
+          <a href="terms.html" class="hover:text-rose-600">Terms</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="py-16">
+        <div class="max-w-4xl mx-auto px-4 bg-white rounded-3xl border border-sand-200 shadow-sm p-8 space-y-6">
+          <header class="space-y-3">
+            <h1 class="text-3xl font-bold text-charcoal-900">Privacy Notice — Demo Experience</h1>
+            <p class="text-charcoal-600">Last updated: March 1, 2025</p>
+            <p class="text-charcoal-600">This website is a simulated marketing and CRM demonstration for a salon franchise. It is designed for educational and sales purposes only.</p>
+          </header>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">Data sources</h2>
+            <p class="text-charcoal-600">All data displayed within the experience is fictional and stored locally in your browser session. Seeded data is loaded from static JSON files bundled with the site.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">Lead capture form</h2>
+            <p class="text-charcoal-600">When you submit the lead form, the information you enter is saved only to your browser’s <code>localStorage</code> under the key <code>demo_leads</code>. No submission is transmitted to a server or third party.</p>
+            <p class="text-charcoal-600">To clear the data, open your browser console and run <code>localStorage.removeItem('demo_leads')</code> or clear site data in your browser settings.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">Analytics</h2>
+            <p class="text-charcoal-600">We include an optional Google Analytics 4 (GA4) snippet for demo measurement. The measurement ID is configurable in <code>data/config.json</code>. By default, only anonymous interaction events (<code>lead_submit</code>, <code>segment_apply</code>, <code>campaign_preview</code>) are tracked, without personally identifiable information.</p>
+            <p class="text-charcoal-600">Disable analytics by setting <code>"enableAnalytics": false</code> in <code>data/config.json</code>. GA4 scripts will not load when disabled.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">Cookies & storage</h2>
+            <ul class="list-disc pl-5 text-charcoal-600 space-y-2">
+              <li>No cookies are set by this demo experience.</li>
+              <li>LocalStorage is used solely for the optional lead capture walkthrough.</li>
+              <li>Static assets are hosted on GitHub Pages and served over HTTPS.</li>
+            </ul>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">Your responsibilities</h2>
+            <p class="text-charcoal-600">Avoid entering real customer data. This environment is not intended for production use or storing personal information.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">Contact</h2>
+            <p class="text-charcoal-600">Questions about this demo? Email <a href="mailto:demo@elevatecrm.com" class="text-rose-600">demo@elevatecrm.com</a>.</p>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+  </body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/scripts/demo-dashboard.js
+++ b/scripts/demo-dashboard.js
@@ -1,0 +1,301 @@
+import { fetchJson, getStoredLeads, obfuscateEmail, formatDate, fireAnalytics, loadConfig } from './utils.js';
+
+let leads = [];
+let segmentsFilters = {
+  location: [],
+  interest: [],
+  membership: [],
+  lastVisit: 'any'
+};
+let templates = [];
+
+function updateSegmentSizeDisplay(text) {
+  document.querySelectorAll('[data-segment-size]').forEach((element) => {
+    element.textContent = text;
+  });
+}
+
+function combineLeads(seed, stored) {
+  const map = new Map();
+  [...seed, ...stored].forEach((lead) => {
+    map.set(lead.id || `${lead.email}-${lead.createdAt}`, lead);
+  });
+  return Array.from(map.values()).sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+}
+
+function renderLeadsTable() {
+  const tbody = document.getElementById('leads-table-body');
+  const emptyState = document.getElementById('leads-empty');
+  if (!tbody || !emptyState) return;
+  if (leads.length === 0) {
+    emptyState.classList.remove('hidden');
+    tbody.innerHTML = '';
+    return;
+  }
+  emptyState.classList.add('hidden');
+  tbody.innerHTML = leads
+    .map(
+      (lead) => `
+        <tr class="border-b border-sand-100 last:border-none">
+          <td class="py-3 px-4 font-medium text-charcoal-900">${lead.firstName} ${lead.lastName}</td>
+          <td class="py-3 px-4 text-charcoal-600">${obfuscateEmail(lead.email)}</td>
+          <td class="py-3 px-4 text-charcoal-600">${lead.preferredLocation}</td>
+          <td class="py-3 px-4 text-charcoal-600">${lead.interestedServices.join(', ')}</td>
+          <td class="py-3 px-4 text-charcoal-600">${lead.membership || 'New'}</td>
+          <td class="py-3 px-4 text-charcoal-500">${formatDate(lead.createdAt)}</td>
+        </tr>
+      `
+    )
+    .join('');
+}
+
+function renderSegmentResults(results) {
+  const container = document.getElementById('segment-results');
+  if (!container) return;
+  if (results.length === 0) {
+    container.innerHTML = `<p class="text-charcoal-600">No leads match the selected filters yet. Adjust filters or capture a new lead to demo reactivation.</p>`;
+    return;
+  }
+  container.innerHTML = `
+    <ul class="space-y-3">
+      ${results
+        .map(
+          (lead) => `
+            <li class="flex items-center justify-between bg-white/70 border border-sand-200 rounded-2xl px-4 py-3">
+              <span class="font-medium text-charcoal-900">${lead.firstName} ${lead.lastName}</span>
+              <span class="text-sm text-charcoal-500">${lead.preferredLocation} • ${lead.interestedServices.join(', ')}</span>
+            </li>
+          `
+        )
+        .join('')}
+    </ul>
+  `;
+}
+
+function applySegmentFilters(shouldFire = true) {
+  let filtered = [...leads];
+  if (segmentsFilters.location.length) {
+    filtered = filtered.filter((lead) => segmentsFilters.location.includes(lead.preferredLocation));
+  }
+  if (segmentsFilters.interest?.length) {
+    filtered = filtered.filter((lead) => lead.interestedServices.some((service) => segmentsFilters.interest.includes(service)));
+  }
+  if (segmentsFilters.membership?.length) {
+    filtered = filtered.filter((lead) => segmentsFilters.membership.includes(lead.membership || 'New'));
+  }
+  if (segmentsFilters.lastVisit && segmentsFilters.lastVisit !== 'any') {
+    const now = new Date();
+    filtered = filtered.filter((lead) => {
+      if (!lead.lastVisit) return segmentsFilters.lastVisit === 'never';
+      if (segmentsFilters.lastVisit === 'never') return false;
+      const daysSinceVisit = (now - new Date(lead.lastVisit)) / (1000 * 60 * 60 * 24);
+      if (segmentsFilters.lastVisit === '30+') {
+        return daysSinceVisit >= 30;
+      }
+      if (segmentsFilters.lastVisit === '60+') {
+        return daysSinceVisit >= 60;
+      }
+      if (segmentsFilters.lastVisit === '90+') {
+        return daysSinceVisit >= 90;
+      }
+      return true;
+    });
+  }
+  const segmentText = `${filtered.length} lead${filtered.length === 1 ? '' : 's'}`;
+  updateSegmentSizeDisplay(segmentText);
+  renderSegmentResults(filtered);
+  if (shouldFire) {
+    fireAnalytics('segment_apply', {
+      filters_applied: Object.entries(segmentsFilters)
+        .filter(([, value]) => (Array.isArray(value) ? value.length : value && value !== 'any'))
+        .map(([key, value]) => `${key}:${Array.isArray(value) ? value.join('|') : value}`)
+        .join(',')
+    });
+  }
+  return filtered;
+}
+
+function setupSegmentFilters(locations) {
+  const locationContainer = document.getElementById('filter-location');
+  const interestContainer = document.getElementById('filter-interest');
+  const membershipContainer = document.getElementById('filter-membership');
+  const lastVisitSelect = document.getElementById('filter-last-visit');
+
+  if (locationContainer) {
+    locations.forEach((loc) => {
+      const option = document.createElement('label');
+      option.className = 'flex items-center gap-2';
+      option.innerHTML = `<input type="checkbox" value="${loc.name}" class="accent-rose-500"> <span>${loc.name}</span>`;
+      locationContainer.appendChild(option);
+    });
+    locationContainer.addEventListener('change', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement) {
+        if (target.checked) {
+          segmentsFilters.location.push(target.value);
+        } else {
+          segmentsFilters.location = segmentsFilters.location.filter((value) => value !== target.value);
+        }
+        applySegmentFilters();
+      }
+    });
+  }
+
+  const interests = new Set();
+  leads.forEach((lead) => lead.interestedServices.forEach((service) => interests.add(service)));
+  if (interestContainer) {
+    interests.forEach((interest) => {
+      const option = document.createElement('label');
+      option.className = 'flex items-center gap-2';
+      option.innerHTML = `<input type="checkbox" value="${interest}" class="accent-rose-500"> <span>${interest}</span>`;
+      interestContainer.appendChild(option);
+    });
+    interestContainer.addEventListener('change', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement) {
+        if (target.checked) {
+          segmentsFilters.interest.push(target.value);
+        } else {
+          segmentsFilters.interest = segmentsFilters.interest.filter((value) => value !== target.value);
+        }
+        applySegmentFilters();
+      }
+    });
+  }
+
+  const memberships = new Set(leads.map((lead) => lead.membership || 'New'));
+  if (membershipContainer) {
+    memberships.forEach((membership) => {
+      const option = document.createElement('label');
+      option.className = 'flex items-center gap-2';
+      option.innerHTML = `<input type="checkbox" value="${membership}" class="accent-rose-500"> <span>${membership}</span>`;
+      membershipContainer.appendChild(option);
+    });
+    membershipContainer.addEventListener('change', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement) {
+        if (target.checked) {
+          segmentsFilters.membership.push(target.value);
+        } else {
+          segmentsFilters.membership = segmentsFilters.membership.filter((value) => value !== target.value);
+        }
+        applySegmentFilters();
+      }
+    });
+  }
+
+  if (lastVisitSelect) {
+    lastVisitSelect.addEventListener('change', (event) => {
+      segmentsFilters.lastVisit = event.target.value;
+      applySegmentFilters();
+    });
+  }
+}
+
+function renderTemplates(templatesData) {
+  const select = document.getElementById('campaign-template');
+  if (!select) return;
+  select.innerHTML = templatesData
+    .map((template) => `<option value="${template.id}">${template.name}</option>`)
+    .join('');
+}
+
+function populateCampaignForm(template) {
+  document.getElementById('campaign-headline').value = template.email.headline;
+  document.getElementById('campaign-body').value = template.email.body;
+  document.getElementById('campaign-offer').value = template.email.cta;
+  document.getElementById('campaign-subject').value = template.email.subject;
+  document.getElementById('campaign-sms').value = template.sms.text;
+}
+
+function renderPreviews(template) {
+  const emailPreview = document.getElementById('email-preview');
+  const smsPreview = document.getElementById('sms-preview');
+  if (!emailPreview) return;
+  const headline = document.getElementById('campaign-headline').value;
+  const body = document.getElementById('campaign-body').value;
+  const offer = document.getElementById('campaign-offer').value;
+  const subject = document.getElementById('campaign-subject').value;
+  const sms = document.getElementById('campaign-sms').value;
+  emailPreview.innerHTML = `
+    <div class="max-w-xl mx-auto bg-white shadow-lg rounded-3xl overflow-hidden border border-sand-200">
+      <div class="bg-rose-500 text-white px-6 py-4">
+        <p class="text-sm uppercase tracking-wide">${template.name}</p>
+        <h3 class="text-2xl font-semibold">${headline}</h3>
+      </div>
+      <div class="px-6 py-6 space-y-4 text-charcoal-700">
+        <p class="text-sm font-semibold uppercase text-rose-500">Subject: ${subject}</p>
+        <p>${body}</p>
+        <button class="bg-rose-500 text-white px-4 py-2 rounded-full font-medium" type="button">${offer}</button>
+      </div>
+    </div>
+  `;
+  if (smsPreview && window.demoConfig?.features?.enableSmsPreview !== false) {
+    smsPreview.innerHTML = `
+      <div class="bg-charcoal-900 text-white p-4 rounded-3xl max-w-xs mx-auto shadow-inner">
+        <div class="bg-rose-500 text-white px-3 py-2 rounded-2xl rounded-bl-none inline-block">${sms}</div>
+      </div>
+    `;
+  }
+}
+
+function handleTemplateChange(event) {
+  const selectedId = event.target.value;
+  const template = templates.find((item) => item.id === selectedId);
+  if (!template) return;
+  populateCampaignForm(template);
+  renderPreviews(template);
+}
+
+function handlePreviewClick(template) {
+  const segmentDisplay = document.querySelector('[data-segment-size]');
+  const segmentSize = segmentDisplay ? segmentDisplay.textContent : '0 leads';
+  renderPreviews(template);
+  fireAnalytics('campaign_preview', {
+    template_id: template.id,
+    segment_size: segmentSize
+  });
+}
+
+export async function initDemoDashboard() {
+  await loadConfig();
+  const [seedLeads, locations, campaignTemplates] = await Promise.all([
+    fetchJson('data/leads.json'),
+    fetchJson('data/locations.json'),
+    fetchJson('data/campaigns.json')
+  ]);
+  const stored = getStoredLeads();
+  leads = combineLeads(seedLeads, stored);
+  templates = campaignTemplates;
+  renderLeadsTable();
+  setupSegmentFilters(locations);
+  applySegmentFilters(false);
+  renderTemplates(templates);
+
+  document.getElementById('refresh-leads')?.addEventListener('click', () => {
+    const updatedStored = getStoredLeads();
+    leads = combineLeads(seedLeads, updatedStored);
+    renderLeadsTable();
+    applySegmentFilters(false);
+  });
+
+  const templateSelect = document.getElementById('campaign-template');
+  templateSelect?.addEventListener('change', (event) => handleTemplateChange(event));
+  if (templateSelect) {
+    handleTemplateChange({ target: templateSelect });
+  }
+
+  document.getElementById('preview-campaign')?.addEventListener('click', () => {
+    const selectedId = templateSelect?.value;
+    const template = templates.find((item) => item.id === selectedId);
+    if (!template) return;
+    template.email.headline = document.getElementById('campaign-headline').value;
+    template.email.body = document.getElementById('campaign-body').value;
+    template.email.cta = document.getElementById('campaign-offer').value;
+    template.email.subject = document.getElementById('campaign-subject').value;
+    template.sms.text = document.getElementById('campaign-sms').value;
+    handlePreviewClick(template);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initDemoDashboard);

--- a/scripts/lead-form.js
+++ b/scripts/lead-form.js
@@ -1,0 +1,112 @@
+import { fetchJson, storeLead, fireAnalytics, loadConfig } from './utils.js';
+
+function generateId(prefix = 'ld') {
+  return `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getFormData(form) {
+  const formData = new FormData(form);
+  const interestedServices = formData.getAll('interestedServices');
+  return {
+    id: generateId(),
+    firstName: formData.get('firstName').trim(),
+    lastName: formData.get('lastName').trim(),
+    email: formData.get('email').trim(),
+    phone: formData.get('phone').trim(),
+    preferredLocation: formData.get('preferredLocation'),
+    interestedServices,
+    marketingConsent: formData.get('marketingConsent') === 'on',
+    membership: 'New',
+    lastVisit: null,
+    createdAt: new Date().toISOString()
+  };
+}
+
+function showSuccessState(form, lead) {
+  const success = document.getElementById('lead-success');
+  const summary = document.getElementById('lead-summary');
+  if (success && summary) {
+    success.classList.remove('hidden');
+    summary.innerHTML = `Thanks ${lead.firstName}! Our team from <span class="font-semibold">${lead.preferredLocation}</span> will reach out within one business day.`;
+  }
+  form.classList.add('hidden');
+  document.getElementById('lead-next-steps')?.classList.remove('hidden');
+}
+
+function displayErrors(errors) {
+  const container = document.getElementById('lead-errors');
+  if (!container) return;
+  if (errors.length === 0) {
+    container.classList.add('hidden');
+    container.innerHTML = '';
+    return;
+  }
+  container.classList.remove('hidden');
+  container.innerHTML = `<ul class="list-disc pl-5">${errors.map((err) => `<li>${err}</li>`).join('')}</ul>`;
+}
+
+function validate(form) {
+  const errors = [];
+  const firstName = form.firstName.value.trim();
+  const lastName = form.lastName.value.trim();
+  const email = form.email.value.trim();
+  const preferredLocation = form.preferredLocation.value;
+  if (!firstName) errors.push('First name is required.');
+  if (!lastName) errors.push('Last name is required.');
+  if (!email) {
+    errors.push('Email is required.');
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.push('Enter a valid email address.');
+  }
+  if (!preferredLocation) errors.push('Select a preferred location.');
+  return errors;
+}
+
+async function populateServices() {
+  const services = await fetchJson('data/services.json');
+  const select = document.getElementById('interestedServices');
+  if (!select) return;
+  services.forEach((service) => {
+    const option = document.createElement('option');
+    option.value = service.name;
+    option.textContent = service.name;
+    select.appendChild(option);
+  });
+}
+
+async function populateLocations() {
+  const locations = await fetchJson('data/locations.json');
+  const select = document.getElementById('preferredLocation');
+  if (!select) return;
+  locations.forEach((loc) => {
+    const option = document.createElement('option');
+    option.value = loc.name;
+    option.textContent = loc.name;
+    select.appendChild(option);
+  });
+}
+
+export async function initLeadForm() {
+  await loadConfig();
+  await Promise.all([populateServices(), populateLocations()]);
+  const form = document.getElementById('lead-form');
+  if (!form) return;
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const errors = validate(form);
+    displayErrors(errors);
+    if (errors.length > 0) {
+      return;
+    }
+    const lead = getFormData(form);
+    storeLead(lead);
+    fireAnalytics('lead_submit', {
+      interests_count: lead.interestedServices.length,
+      location_selected: lead.preferredLocation
+    });
+    showSuccessState(form, lead);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initLeadForm);

--- a/scripts/locations.js
+++ b/scripts/locations.js
@@ -1,0 +1,62 @@
+import { fetchJson } from './utils.js';
+
+function renderLocations(locations) {
+  const container = document.getElementById('locations-list');
+  if (!container) return;
+  if (locations.length === 0) {
+    container.innerHTML = `
+      <div class="text-center bg-white/70 p-8 rounded-3xl border border-sand-200">
+        <p class="text-lg text-charcoal-600">No locations match your filters. Try expanding your search to see the franchise reach.</p>
+      </div>
+    `;
+    return;
+  }
+  container.innerHTML = locations
+    .map(
+      (loc) => `
+        <article class="bg-white rounded-3xl border border-sand-200 shadow-sm p-6 flex flex-col gap-4">
+          <div>
+            <h3 class="text-2xl font-semibold text-charcoal-900">${loc.name}</h3>
+            <p class="text-charcoal-500">${loc.address}</p>
+          </div>
+          <div class="flex flex-wrap gap-3 text-sm text-charcoal-600">
+            <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">call</span>${loc.phone}</span>
+            <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">schedule</span>${loc.hours}</span>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            ${loc.services
+              .map((service) => `<span class="px-3 py-1 bg-sand-100 text-sand-700 rounded-full text-sm">${service}</span>`)
+              .join('')}
+          </div>
+          <a href="index.html#lead" class="text-rose-600 font-medium inline-flex items-center gap-2 hover:text-rose-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500">Book a consultation<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a>
+        </article>
+      `
+    )
+    .join('');
+}
+
+function applyFilters(locations) {
+  const city = document.getElementById('filter-city').value.trim().toLowerCase();
+  const state = document.getElementById('filter-state').value.trim().toLowerCase();
+  const zip = document.getElementById('filter-zip').value.trim();
+  return locations.filter((loc) => {
+    const matchesCity = city ? loc.city.toLowerCase().includes(city) : true;
+    const matchesState = state ? loc.state.toLowerCase().includes(state) : true;
+    const matchesZip = zip ? loc.zip.startsWith(zip) : true;
+    return matchesCity && matchesState && matchesZip;
+  });
+}
+
+export async function initLocations() {
+  const locations = await fetchJson('data/locations.json');
+  renderLocations(locations);
+  const inputs = document.querySelectorAll('[data-location-filter]');
+  inputs.forEach((input) =>
+    input.addEventListener('input', () => {
+      const filtered = applyFilters(locations);
+      renderLocations(filtered);
+    })
+  );
+}
+
+document.addEventListener('DOMContentLoaded', initLocations);

--- a/scripts/navigation.js
+++ b/scripts/navigation.js
@@ -1,0 +1,23 @@
+function setupKeyboardShortcut() {
+  document.addEventListener('keydown', (event) => {
+    if ((event.key === 'd' || event.key === 'D') && !event.altKey && !event.metaKey && !event.ctrlKey) {
+      window.location.href = 'demo.html';
+    }
+  });
+}
+
+function setupMobileMenu() {
+  const toggle = document.getElementById('nav-toggle');
+  const menu = document.getElementById('mobile-menu');
+  if (!toggle || !menu) return;
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', (!expanded).toString());
+    menu.classList.toggle('hidden');
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupKeyboardShortcut();
+  setupMobileMenu();
+});

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -1,0 +1,30 @@
+import { fetchJson } from './utils.js';
+
+function renderServices(services) {
+  const container = document.getElementById('services-grid');
+  if (!container) return;
+  container.innerHTML = services
+    .map(
+      (service) => `
+        <article id="${service.id}" class="bg-white rounded-3xl border border-sand-200 shadow-sm p-6 flex flex-col gap-4">
+          <div>
+            <h3 class="text-2xl font-semibold text-charcoal-900">${service.name}</h3>
+            <p class="text-sm text-rose-600">${service.priceRange}</p>
+          </div>
+          <p class="text-charcoal-600">${service.description}</p>
+          <div class="flex flex-wrap gap-2">
+            ${service.tags.map((tag) => `<span class="px-3 py-1 bg-rose-100 text-rose-600 rounded-full text-sm">${tag}</span>`).join('')}
+          </div>
+          <a href="index.html#lead" class="inline-flex items-center gap-2 font-semibold text-rose-600 hover:text-rose-700 mt-auto">Book consult<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a>
+        </article>
+      `
+    )
+    .join('');
+}
+
+export async function initServices() {
+  const services = await fetchJson('data/services.json');
+  renderServices(services);
+}
+
+document.addEventListener('DOMContentLoaded', initServices);

--- a/scripts/stylists.js
+++ b/scripts/stylists.js
@@ -1,0 +1,92 @@
+import { fetchJson } from './utils.js';
+
+function renderStylists(stylists) {
+  const container = document.getElementById('stylists-grid');
+  if (!container) return;
+  if (stylists.length === 0) {
+    container.innerHTML = `
+      <div class="col-span-full text-center p-10 bg-white/70 rounded-xl shadow-inner border border-sand-200">
+        <p class="text-lg text-charcoal-600">No stylists match the selected filters. Adjust your selection to explore the franchise talent.</p>
+      </div>
+    `;
+    return;
+  }
+  container.innerHTML = stylists
+    .map(
+      (stylist) => `
+        <article class="bg-white rounded-3xl border border-sand-200 shadow-md overflow-hidden flex flex-col">
+          <img src="${stylist.photo}" alt="${stylist.name}" class="h-56 w-full object-cover" loading="lazy" width="400" height="320">
+          <div class="p-6 flex flex-col gap-4 flex-1">
+            <div>
+              <h3 class="text-xl font-semibold text-charcoal-900">${stylist.name}</h3>
+              <p class="text-sm text-charcoal-500">${stylist.locations.join(', ')}</p>
+            </div>
+            <p class="text-charcoal-700">${stylist.bio}</p>
+            <div class="flex flex-wrap gap-2">
+              ${stylist.specialties
+                .map((spec) => `<span class="inline-flex items-center px-3 py-1 rounded-full bg-rose-100 text-rose-700 text-sm">${spec}</span>`)
+                .join('')}
+            </div>
+            <div class="mt-auto flex items-center justify-between text-sm text-charcoal-500">
+              <span>${stylist.yearsExperience} yrs experience</span>
+              <div class="flex gap-2">
+                ${stylist.badges
+                  .map((badge) => `<span class="px-2.5 py-1 bg-sand-100 text-sand-700 rounded-full">${badge}</span>`)
+                  .join('')}
+              </div>
+            </div>
+          </div>
+        </article>
+      `
+    )
+    .join('');
+}
+
+function applyFilters(stylists) {
+  const location = document.getElementById('stylist-location').value;
+  const specialty = document.getElementById('stylist-specialty').value;
+  return stylists.filter((stylist) => {
+    const matchesLocation = location ? stylist.locations.includes(location) : true;
+    const matchesSpecialty = specialty ? stylist.specialties.includes(specialty) : true;
+    return matchesLocation && matchesSpecialty;
+  });
+}
+
+function populateFilters(stylists) {
+  const locationsSelect = document.getElementById('stylist-location');
+  const specialtySelect = document.getElementById('stylist-specialty');
+  if (!locationsSelect || !specialtySelect) return;
+  const locations = new Set();
+  const specialties = new Set();
+  stylists.forEach((stylist) => {
+    stylist.locations.forEach((loc) => locations.add(loc));
+    stylist.specialties.forEach((spec) => specialties.add(spec));
+  });
+  locations.forEach((loc) => {
+    const option = document.createElement('option');
+    option.value = loc;
+    option.textContent = loc;
+    locationsSelect.appendChild(option);
+  });
+  specialties.forEach((spec) => {
+    const option = document.createElement('option');
+    option.value = spec;
+    option.textContent = spec;
+    specialtySelect.appendChild(option);
+  });
+}
+
+export async function initStylists() {
+  const stylists = await fetchJson('data/stylists.json');
+  populateFilters(stylists);
+  renderStylists(stylists);
+  const filters = document.querySelectorAll('[data-stylist-filter]');
+  filters.forEach((filter) =>
+    filter.addEventListener('change', () => {
+      const filtered = applyFilters(stylists);
+      renderStylists(filtered);
+    })
+  );
+}
+
+document.addEventListener('DOMContentLoaded', initStylists);

--- a/scripts/testimonials.js
+++ b/scripts/testimonials.js
@@ -1,0 +1,84 @@
+import { fetchJson } from './utils.js';
+
+let intervalId;
+
+function renderTestimonials(testimonials) {
+  const container = document.getElementById('testimonial-track');
+  const indicators = document.getElementById('testimonial-indicators');
+  if (!container || !indicators) return;
+  container.innerHTML = testimonials
+    .map(
+      (testimonial, index) => `
+        <div class="min-w-full transition-opacity duration-500" role="group" aria-roledescription="slide" aria-label="Testimonial ${index + 1} of ${testimonials.length}">
+          <div class="bg-white/80 backdrop-blur rounded-2xl shadow-lg p-8 border border-sand-200">
+            <p class="text-lg md:text-xl text-charcoal-700">“${testimonial.quote}”</p>
+            <p class="mt-6 font-semibold text-charcoal-900">${testimonial.name}</p>
+            <p class="text-sm text-charcoal-500">${testimonial.title}</p>
+          </div>
+        </div>
+      `
+    )
+    .join('');
+  indicators.innerHTML = testimonials
+    .map(
+      (_, index) => `
+        <button type="button" class="w-2.5 h-2.5 rounded-full bg-sand-400" aria-label="Go to testimonial ${index + 1}" data-index="${index}"></button>
+      `
+    )
+    .join('');
+}
+
+function setActiveSlide(index) {
+  const slides = document.querySelectorAll('#testimonial-track > div');
+  const dots = document.querySelectorAll('#testimonial-indicators > button');
+  slides.forEach((slide, slideIndex) => {
+    slide.classList.toggle('opacity-100', slideIndex === index);
+    slide.classList.toggle('opacity-0', slideIndex !== index);
+    slide.setAttribute('tabindex', slideIndex === index ? '0' : '-1');
+    slide.setAttribute('aria-hidden', slideIndex === index ? 'false' : 'true');
+  });
+  dots.forEach((dot, dotIndex) => {
+    dot.classList.toggle('bg-rose-500', dotIndex === index);
+    dot.classList.toggle('bg-sand-400', dotIndex !== index);
+  });
+  const wrapper = document.getElementById('testimonial-track');
+  wrapper.style.transform = `translateX(-${index * 100}%)`;
+  wrapper.dataset.activeIndex = index.toString();
+}
+
+function startAutoRotate() {
+  stopAutoRotate();
+  intervalId = window.setInterval(() => {
+    const wrapper = document.getElementById('testimonial-track');
+    if (!wrapper) return;
+    const total = wrapper.children.length;
+    const current = Number(wrapper.dataset.activeIndex || '0');
+    const next = (current + 1) % total;
+    setActiveSlide(next);
+  }, 6000);
+}
+
+function stopAutoRotate() {
+  if (intervalId) window.clearInterval(intervalId);
+}
+
+export async function initTestimonials() {
+  const testimonials = await fetchJson('data/testimonials.json');
+  renderTestimonials(testimonials);
+  const wrapper = document.getElementById('testimonial-wrapper');
+  const indicators = document.getElementById('testimonial-indicators');
+  if (!wrapper || !indicators) return;
+  setActiveSlide(0);
+  startAutoRotate();
+  wrapper.addEventListener('mouseenter', stopAutoRotate);
+  wrapper.addEventListener('mouseleave', startAutoRotate);
+  indicators.addEventListener('click', (event) => {
+    const target = event.target;
+    if (target instanceof HTMLButtonElement && target.dataset.index) {
+      stopAutoRotate();
+      setActiveSlide(Number(target.dataset.index));
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initTestimonials);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,83 @@
+export async function fetchJson(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Failed to load ${path}`);
+  }
+  return response.json();
+}
+
+export function obfuscateEmail(email) {
+  if (!email) return '';
+  const [user, domain] = email.split('@');
+  if (!user || !domain) return email;
+  const maskedUser = user.length <= 2 ? user[0] + '*' : user[0] + '*'.repeat(Math.max(1, user.length - 2)) + user[user.length - 1];
+  return `${maskedUser}@${domain}`;
+}
+
+export function formatDate(dateString) {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+export function getStoredLeads() {
+  const raw = localStorage.getItem('demo_leads');
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Unable to parse stored leads', error);
+    return [];
+  }
+}
+
+export function storeLead(lead) {
+  const existing = getStoredLeads();
+  existing.push(lead);
+  localStorage.setItem('demo_leads', JSON.stringify(existing));
+}
+
+export function fireAnalytics(eventName, params = {}) {
+  if (window.demoConfig?.features?.enableAnalytics && typeof gtag === 'function') {
+    gtag('event', eventName, params);
+  }
+}
+
+export async function loadConfig() {
+  if (window.demoConfig) return window.demoConfig;
+  try {
+    const config = await fetchJson('data/config.json');
+    window.demoConfig = config;
+    if (config.features?.enableAnalytics && config.ga4MeasurementId && !window.__gaLoaded) {
+      injectGA(config.ga4MeasurementId);
+    }
+    return config;
+  } catch (error) {
+    console.warn('Unable to load config', error);
+    return {
+      ga4MeasurementId: '',
+      features: {
+        enableAnalytics: false,
+        enableSmsPreview: true
+      }
+    };
+  }
+}
+
+function injectGA(measurementId) {
+  window.__gaLoaded = true;
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){window.dataLayer.push(arguments);} // eslint-disable-line
+  window.gtag = window.gtag || gtag;
+  gtag('js', new Date());
+  gtag('config', measurementId);
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+  document.head.appendChild(script);
+}

--- a/services.html
+++ b/services.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Services & Pricing | Elevate Salon CRM Demo</title>
+    <meta
+      name="description"
+      content="Explore signature services, memberships, and upsell packages that our CRM promotes for salon franchises."
+    />
+    <meta property="og:title" content="Salon CRM Demo Services" />
+    <meta
+      property="og:description"
+      content="Color, cut, membership, and VIP offers—see how Elevate CRM activates every service line."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80" />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+            <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+              <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+            </span>
+            Elevate CRM
+          </a>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+            <a href="index.html" class="hover:text-rose-600">Home</a>
+            <a href="services.html" class="text-rose-600">Services</a>
+            <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+            <a href="locations.html" class="hover:text-rose-600">Locations</a>
+            <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+            <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+          </nav>
+          <div class="flex items-center gap-4">
+            <a href="index.html#lead" class="hidden md:inline-flex primary-btn text-sm">Get a free consultation</a>
+            <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+              <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="services.html" class="text-rose-600">Services</a>
+          <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+          <a href="locations.html" class="hover:text-rose-600">Locations</a>
+          <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="bg-hero border-b border-sand-100">
+        <div class="max-w-6xl mx-auto px-4 py-16 grid md:grid-cols-[1.2fr_1fr] gap-10 items-center">
+          <div class="space-y-6">
+            <h1 class="text-4xl font-bold text-charcoal-900">Services that sell themselves—when the right guests see them.</h1>
+            <p class="text-lg text-charcoal-600">Elevate CRM keeps every salon location aligned on pricing, add-ons, and memberships so marketers can launch campaigns without hunting down spreadsheets.</p>
+            <div class="flex flex-wrap gap-4 text-sm text-charcoal-600">
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">precision_manufacturing</span>Centralized menu management</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">mail</span>One-click campaign previews</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">monitoring</span>Performance by location</span>
+            </div>
+          </div>
+          <aside class="bg-white rounded-3xl border border-sand-200 shadow-lg p-6 space-y-4">
+            <h2 class="text-xl font-semibold text-charcoal-900">Quick links</h2>
+            <ul class="space-y-3 text-charcoal-600" id="service-links">
+              <li><a href="#svc_color_refresh" class="hover:text-rose-600">Color Refresh & Gloss</a></li>
+              <li><a href="#svc_signature_cut" class="hover:text-rose-600">Signature Cut & Finish</a></li>
+              <li><a href="#svc_extension_volume" class="hover:text-rose-600">Volume Extension Package</a></li>
+              <li><a href="#svc_men_groom" class="hover:text-rose-600">Modern Men's Grooming</a></li>
+              <li><a href="#svc_membership" class="hover:text-rose-600">Blowout Society Membership</a></li>
+            </ul>
+            <a href="index.html#lead" class="primary-btn w-full justify-center">Plan a revenue sprint</a>
+          </aside>
+        </div>
+      </section>
+
+      <section class="py-20">
+        <div class="max-w-6xl mx-auto px-4">
+          <h2 class="section-heading mb-8">Featured experiences</h2>
+          <div id="services-grid" class="grid md:grid-cols-2 gap-8"></div>
+        </div>
+      </section>
+
+      <section class="py-16 bg-sand-50 border-y border-sand-100">
+        <div class="max-w-6xl mx-auto px-4 grid md:grid-cols-2 gap-8 items-center">
+          <div class="space-y-4">
+            <h2 class="section-heading">Memberships that boost retention by 28%</h2>
+            <p class="text-charcoal-600">Bundle blowouts, treatments, and retail perks into automated journeys. Our CRM tracks utilization so you can identify churn risks before they leave.</p>
+            <ul class="space-y-3 text-charcoal-600">
+              <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">auto_graph</span>Spot low-frequency guests instantly</li>
+              <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">redeem</span>Trigger automated surprise-and-delight offers</li>
+              <li class="flex gap-3"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">forum</span>Sync campaign scripts to every stylist station</li>
+            </ul>
+          </div>
+          <img
+            src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=900&q=80"
+            alt="Stylist consulting with a guest"
+            class="rounded-3xl shadow-lg border border-sand-200"
+            loading="lazy"
+            width="600"
+            height="420"
+          />
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+    <script src="scripts/services.js" type="module"></script>
+  </body>
+</html>

--- a/services.html
+++ b/services.html
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,123 @@
+:root {
+  --sand-50: #fdf9f4;
+  --sand-100: #f7ece2;
+  --sand-200: #edd9c5;
+  --sand-400: #d0b292;
+  --sand-700: #8a6642;
+  --charcoal-900: #1d1b19;
+  --charcoal-700: #3f3a34;
+  --charcoal-600: #5a534b;
+  --charcoal-500: #7d7469;
+  --rose-100: #fde7e9;
+  --rose-500: #d6456e;
+  --rose-600: #b8345a;
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: linear-gradient(180deg, rgba(253, 249, 244, 0.9) 0%, rgba(255, 255, 255, 0.9) 100%);
+  color: var(--charcoal-900);
+}
+
+.bg-hero {
+  background: radial-gradient(circle at top left, rgba(214, 69, 110, 0.15), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(224, 173, 121, 0.2), transparent 45%),
+    #fff;
+}
+
+.text-charcoal-900 { color: var(--charcoal-900); }
+.text-charcoal-700 { color: var(--charcoal-700); }
+.text-charcoal-600 { color: var(--charcoal-600); }
+.text-charcoal-500 { color: var(--charcoal-500); }
+.text-rose-500 { color: var(--rose-500); }
+.text-rose-600 { color: var(--rose-600); }
+.bg-sand-50 { background-color: var(--sand-50); }
+.bg-sand-100 { background-color: var(--sand-100); }
+.bg-sand-200 { background-color: var(--sand-200); }
+.bg-rose-500 { background-color: var(--rose-500); }
+.bg-rose-100 { background-color: var(--rose-100); }
+.text-sand-700 { color: var(--sand-700); }
+
+.primary-btn {
+  background-color: var(--rose-500);
+  color: white;
+  border-radius: 9999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.primary-btn:hover,
+.primary-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(214, 69, 110, 0.25);
+  outline: none;
+}
+
+.section-heading {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 700;
+}
+
+.gradient-border {
+  position: relative;
+  border-radius: 2rem;
+  padding: 1px;
+  background: linear-gradient(120deg, rgba(214, 69, 110, 0.35), rgba(207, 175, 119, 0.2));
+}
+
+.gradient-border > .inner {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: calc(2rem - 1px);
+  height: 100%;
+  width: 100%;
+}
+
+.material-symbols-rounded {
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 500,
+    'GRAD' 0,
+    'opsz' 48;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.tab-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 0;
+  min-width: 120px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--charcoal-600);
+  border-bottom: 2px solid transparent;
+  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease;
+}
+
+.tab-btn:hover {
+  color: var(--rose-600);
+}
+
+.tab-btn:focus-visible {
+  outline: 2px solid var(--rose-500);
+  outline-offset: 2px;
+}
+
+.tab-panel {
+  background-color: rgba(255, 255, 255, 0.96);
+}

--- a/stylists.html
+++ b/stylists.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/stylists.html
+++ b/stylists.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Meet the Stylists | Elevate Salon CRM Demo</title>
+    <meta
+      name="description"
+      content="Discover top stylists across the franchise, filter by specialty, and showcase how CRM insights power utilization."
+    />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+            <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+              <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+            </span>
+            Elevate CRM
+          </a>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+            <a href="index.html" class="hover:text-rose-600">Home</a>
+            <a href="services.html" class="hover:text-rose-600">Services</a>
+            <a href="stylists.html" class="text-rose-600">Stylists</a>
+            <a href="locations.html" class="hover:text-rose-600">Locations</a>
+            <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+            <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+          </nav>
+          <div class="flex items-center gap-4">
+            <a href="index.html#lead" class="hidden md:inline-flex primary-btn text-sm">Get a free consultation</a>
+            <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+              <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="services.html" class="hover:text-rose-600">Services</a>
+          <a href="stylists.html" class="text-rose-600">Stylists</a>
+          <a href="locations.html" class="hover:text-rose-600">Locations</a>
+          <a href="testimonials.html" class="hover:text-rose-600">Testimonials</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="bg-hero border-b border-sand-100">
+        <div class="max-w-6xl mx-auto px-4 py-16 grid md:grid-cols-2 gap-12 items-center">
+          <div class="space-y-6">
+            <h1 class="text-4xl font-bold text-charcoal-900">Spotlight every artist—and seat them with their dream guests.</h1>
+            <p class="text-lg text-charcoal-600">Filter by location, specialties, and accolades. Elevate CRM helps franchises balance utilization and highlight VIP-ready stylists.</p>
+            <div class="flex flex-wrap gap-4 text-sm text-charcoal-600">
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">emoji_events</span>Badge tracking</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">calendar_month</span>Availability insights</span>
+              <span class="inline-flex items-center gap-2"><span class="material-symbols-rounded text-rose-500" aria-hidden="true">query_stats</span>Productivity dashboards</span>
+            </div>
+          </div>
+          <div class="bg-white rounded-3xl border border-sand-200 shadow-lg p-6 space-y-4">
+            <h2 class="text-xl font-semibold text-charcoal-900">Filter stylists</h2>
+            <div class="space-y-4">
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Location
+                <select id="stylist-location" data-stylist-filter class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3">
+                  <option value="">All locations</option>
+                </select>
+              </label>
+              <label class="block text-sm font-medium text-charcoal-700"
+                >Specialty
+                <select id="stylist-specialty" data-stylist-filter class="mt-1 w-full rounded-2xl border border-sand-200 px-4 py-3">
+                  <option value="">All specialties</option>
+                </select>
+              </label>
+              <a href="index.html#lead" class="inline-flex items-center gap-2 text-rose-600 font-semibold hover:text-rose-700">Need a stylist rollout plan?<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-20">
+        <div class="max-w-6xl mx-auto px-4">
+          <h2 class="section-heading mb-8">Franchise talent directory</h2>
+          <div id="stylists-grid" class="grid md:grid-cols-2 xl:grid-cols-3 gap-8"></div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+    <script src="scripts/stylists.js" type="module"></script>
+  </body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Terms of Use | Elevate Salon CRM Demo</title>
+    <meta
+      name="description"
+      content="Terms governing the use of the Elevate Salon CRM demo experience hosted on GitHub Pages."
+    />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col bg-sand-50">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/90 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+            <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+          </span>
+          Elevate CRM
+        </a>
+        <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="privacy.html" class="hover:text-rose-600">Privacy</a>
+          <a href="terms.html" class="text-rose-600">Terms</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+        <div class="flex items-center gap-4">
+          <a href="index.html#lead" class="hidden md:inline-flex primary-btn text-sm">Book a walkthrough</a>
+          <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+            <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+          </button>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="privacy.html" class="hover:text-rose-600">Privacy</a>
+          <a href="terms.html" class="text-rose-600">Terms</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="py-16">
+        <div class="max-w-4xl mx-auto px-4 bg-white rounded-3xl border border-sand-200 shadow-sm p-8 space-y-6">
+          <header class="space-y-3">
+            <h1 class="text-3xl font-bold text-charcoal-900">Terms of Use</h1>
+            <p class="text-charcoal-600">Last updated: March 1, 2025</p>
+            <p class="text-charcoal-600">These terms govern your use of the Elevate Salon CRM demo website (the “Demo”). By accessing the Demo you agree to these terms.</p>
+          </header>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">1. Demo purpose</h2>
+            <p class="text-charcoal-600">The Demo is provided solely for illustrative, educational, and sales enablement purposes. It is not a production service. Content and features are fictitious and may change without notice.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">2. No real customer data</h2>
+            <p class="text-charcoal-600">Do not input real customer, employee, or personal data. Any information you provide is stored locally within your browser and can be cleared at any time.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">3. Intellectual property</h2>
+            <p class="text-charcoal-600">All text, design, code, and creative assets within the Demo are owned by the creators and are licensed for viewing only. You may not reuse or distribute assets without permission.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">4. Disclaimer of warranties</h2>
+            <p class="text-charcoal-600">The Demo is provided “as-is” without warranties of any kind. We disclaim all implied warranties including merchantability, fitness for a particular purpose, and non-infringement.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">5. Limitation of liability</h2>
+            <p class="text-charcoal-600">To the fullest extent permitted by law, we are not liable for any damages arising from or related to your use of the Demo, including direct, indirect, incidental, or consequential damages.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">6. Updates</h2>
+            <p class="text-charcoal-600">We may update these terms at any time by posting a revised version on this page. Continued use of the Demo constitutes acceptance of the updated terms.</p>
+          </section>
+
+          <section class="space-y-3">
+            <h2 class="text-xl font-semibold text-charcoal-900">7. Contact</h2>
+            <p class="text-charcoal-600">For questions regarding these terms contact <a href="mailto:demo@elevatecrm.com" class="text-rose-600">demo@elevatecrm.com</a>.</p>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+  </body>
+</html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Testimonials | Elevate Salon CRM Demo</title>
+    <meta
+      name="description"
+      content="Hear from salon franchise leaders using Elevate CRM to accelerate lead capture, membership growth, and stylist performance."
+    />
+    <link rel="icon" href="https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f487-200d-2640-fe0f.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="styles/theme.css" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    </script>
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <a href="#main" class="absolute left-4 top-4 bg-white text-charcoal-900 px-3 py-2 rounded-full shadow focus:not-sr-only sr-only focus:sr-only">Skip to main content</a>
+    <header class="sticky top-0 z-50 backdrop-blur bg-white/80 border-b border-sand-100">
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center gap-3 text-xl font-semibold text-charcoal-900">
+            <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-rose-500 text-white">
+              <span class="material-symbols-rounded" aria-hidden="true">content_cut</span>
+            </span>
+            Elevate CRM
+          </a>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-charcoal-700">
+            <a href="index.html" class="hover:text-rose-600">Home</a>
+            <a href="services.html" class="hover:text-rose-600">Services</a>
+            <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+            <a href="locations.html" class="hover:text-rose-600">Locations</a>
+            <a href="testimonials.html" class="text-rose-600">Testimonials</a>
+            <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+          </nav>
+          <div class="flex items-center gap-4">
+            <a href="index.html#lead" class="hidden md:inline-flex primary-btn text-sm">Get a free consultation</a>
+            <button id="nav-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-full border border-sand-200 text-charcoal-700" aria-expanded="false" aria-controls="mobile-menu" aria-label="Toggle navigation">
+              <span class="material-symbols-rounded" aria-hidden="true">menu</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div id="mobile-menu" class="md:hidden hidden border-t border-sand-100 bg-white/95">
+        <nav class="px-4 py-4 flex flex-col gap-3 text-sm font-medium text-charcoal-700">
+          <a href="index.html" class="hover:text-rose-600">Home</a>
+          <a href="services.html" class="hover:text-rose-600">Services</a>
+          <a href="stylists.html" class="hover:text-rose-600">Stylists</a>
+          <a href="locations.html" class="hover:text-rose-600">Locations</a>
+          <a href="testimonials.html" class="text-rose-600">Testimonials</a>
+          <a href="index.html#lead" class="hover:text-rose-600">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="flex-1">
+      <section class="bg-hero border-b border-sand-100">
+        <div class="max-w-4xl mx-auto px-4 py-20 text-center space-y-6">
+          <h1 class="text-4xl font-bold text-charcoal-900">Proof that guest journeys can feel personal at scale.</h1>
+          <p class="text-lg text-charcoal-600">Elevate CRM equips marketers and operators with insights, automations, and previews they can trust. Here’s what franchise leaders have to say.</p>
+          <a href="index.html#lead" class="primary-btn justify-center">Book a guided demo</a>
+        </div>
+      </section>
+
+      <section class="py-20">
+        <div class="max-w-5xl mx-auto px-4 space-y-12">
+          <div id="testimonial-wrapper" class="relative overflow-hidden rounded-3xl border border-sand-200 bg-white/50" tabindex="0">
+            <div id="testimonial-track" class="flex transition-transform duration-500" data-active-index="0"></div>
+            <div class="flex justify-center gap-3 py-6" id="testimonial-indicators" role="tablist" aria-label="Testimonials"></div>
+          </div>
+          <div class="grid md:grid-cols-2 gap-8">
+            <article class="bg-white rounded-3xl border border-sand-200 p-6 shadow-sm">
+              <h2 class="text-xl font-semibold text-charcoal-900">Why it resonates in demos</h2>
+              <p class="mt-3 text-charcoal-600">“Account executives can capture a lead live, refresh the dashboard, and show segments in 10 seconds. It’s the ‘aha’ moment for owners.”</p>
+              <p class="mt-4 text-sm text-charcoal-500">— Demo Strategy Team</p>
+            </article>
+            <article class="bg-white rounded-3xl border border-sand-200 p-6 shadow-sm">
+              <h2 class="text-xl font-semibold text-charcoal-900">What members love</h2>
+              <p class="mt-3 text-charcoal-600">“Guests feel remembered. They walk in quoting the SMS they just received, and stylists know exactly which offer brought them back.”</p>
+              <p class="mt-4 text-sm text-charcoal-500">— Franchise Success Manager</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-charcoal-900 text-sand-50">
+      <div class="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8 text-sm">
+        <div class="space-y-3">
+          <p class="text-base font-semibold text-white">Elevate CRM for Salons</p>
+          <p class="text-sand-200">Simulated data for demo purposes only. No personal information stored on servers.</p>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Franchise resources</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="services.html" class="hover:text-white">Services & Pricing</a></li>
+            <li><a href="locations.html" class="hover:text-white">Locations</a></li>
+            <li><a href="stylists.html" class="hover:text-white">Stylists</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Company</p>
+          <ul class="space-y-2 text-sand-200">
+            <li><a href="privacy.html" class="hover:text-white">Privacy</a></li>
+            <li><a href="terms.html" class="hover:text-white">Terms</a></li>
+            <li><a href="mailto:demo@elevatecrm.com" class="hover:text-white">Contact sales</a></li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <p class="font-semibold text-white">Connect</p>
+          <div class="flex gap-4 text-xl text-sand-200">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn" class="hover:text-white">in</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" class="hover:text-white">IG</a>
+            <a href="https://www.tiktok.com" aria-label="TikTok" class="hover:text-white">TT</a>
+          </div>
+          <a href="demo.html" class="text-sand-200 hover:text-white text-xs" rel="nofollow">Demo dashboard</a>
+        </div>
+      </div>
+      <div class="px-4 py-4 text-center text-xs text-sand-400">© 2025 Elevate CRM Demo. Crafted for showcase purposes.</div>
+    </footer>
+
+    <script src="scripts/navigation.js" type="module"></script>
+    <script src="scripts/testimonials.js" type="module"></script>
+  </body>
+</html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="styles/theme.css" />
     <script>
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary
- implement a GitHub Pages-ready marketing site with hero, services, stylists, locations, testimonials, and legal pages tailored to salon franchises
- add GA4-configurable lead form that stores submissions in localStorage and seeds demo data via JSON
- deliver a `/demo` dashboard with leads table, segment builder, and campaign previews for email/SMS storytelling

## Testing
- n/a (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9d814fa848330bdd4b596cb009b71